### PR TITLE
Fix badge URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DeepCell Datasets: Master Data Management for DeepCell
 
-[![Actions Status](https://github.com/vanvalenlab/deepcell-datasets/workflows/browser/badge.svg)](https://github.com/vanvalenlab/deepcell-datasets/actions)
+[![Actions Status](https://github.com/vanvalenlab/deepcell-datasets/workflows/Test%20API/badge.svg)](https://github.com/vanvalenlab/deepcell-datasets/actions)
 [![Coverage Status](https://coveralls.io/repos/github/vanvalenlab/deepcell-datasets/badge.svg?branch=master)](https://coveralls.io/github/vanvalenlab/deepcell-datasets?branch=master)
 
 DeepCell Datasets is a collection of data engineering and versioning tools for the management of optical microscopy images and its associated metadata. This Master Data Management allows for a single entry point for access to the lab's raw data and provides to means to pair them with crowdsourced annotations to create custom training data for [DeepCell](https://github.com/vanvalenlab/deepcell-tf).


### PR DESCRIPTION
The name of the workflow is shown in the badge. Is "Test API" good enough? We could just call it "build" instead to more closely match the other badges we have.