### PR TITLE
Include email link in SignUp help text.

### DIFF
--- a/frontend/src/auth/SignUpContainer.tsx
+++ b/frontend/src/auth/SignUpContainer.tsx
@@ -126,6 +126,7 @@ export default function SignUpContainer() {
               isValid={email.length > 0 && isValidEmail} />
             <Form.Text muted>
               Enter a valid university email address.
+              Please contact <a href={'mailto:info@deepcell.org'}>info@deepcell.org</a> if your academic domain is not supported.
             </Form.Text>
           </Form.Group>
 


### PR DESCRIPTION
Many users have contacted us with non `.edu` emails that are still academic institutions. Adding a link to the Sign Up Page will help users that cannot register reach the team to get their domain whitelisted.