### PR TITLE
Add dropdown for dataset versions

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "jsxSingleQuote": true
+}

--- a/frontend/src/datasets/AllDatasets.tsx
+++ b/frontend/src/datasets/AllDatasets.tsx
@@ -1,26 +1,57 @@
 /**
- * For the POC the "data" will just be hard coded.
+ * For the proof of concept the "data" will just be hard coded.
  *
  * The next step would be to load this from a Data API
  * Hopefully a Lambda+DynamoDB serverless API!
  */
 
-const AllDatasets = [
+interface Version {
+  version: string;
+  description: string;
+  objectKey: string;
+}
+
+export interface Dataset {
+  title: string;
+  samples: string;
+  imagingPlatform: string;
+  thumbnail: string;
+  versions: Version[];
+}
+
+const AllDatasets: Dataset[] = [
   {
-    title: 'TissueNet Version v1.0',
-    objectKey: 'tissuenet/tissuenet_v1.0.zip',
+    title: 'TissueNet',
     thumbnail: '/images/multiplex_overlay.webp',
     imagingPlatform: 'Multiplexed imaging',
     samples: '2D tissue',
-    description: 'This is the first release of the TissueNet dataset from Greenwald, Miller et al.',
+    versions: [
+      {
+        version: '1.0',
+        description:
+          'This is the first release of the TissueNet dataset from Greenwald, Miller et al.',
+        objectKey: 'tissuenet/tissuenet_v1.0.zip',
+      },
+      {
+        version: '1.1',
+        description:
+          'This is the second release of the TissueNet dataset from Greenwald, Miller et al.',
+        objectKey: 'tissuenet/tissuenet_v1.1.zip',
+      },
+    ],
   },
   {
-    title: 'LiveCellNet v0.1',
-    objectKey: 'tracking-nuclear/val.trks',
+    title: 'LiveCellNet',
     thumbnail: '/images/3t3_nuclear_outlines.webp',
     imagingPlatform: 'Fluorescent Microscopy',
     samples: '2D culture',
-    description: 'This is a subset of the Nuclear Tracking dataset.',
+    versions: [
+      {
+        version: '0.1',
+        description: 'This is a subset of the Nuclear Tracking dataset.',
+        objectKey: 'tracking-nuclear/val.trks',
+      },
+    ],
   },
 ];
 

--- a/frontend/src/datasets/Data.tsx
+++ b/frontend/src/datasets/Data.tsx
@@ -18,15 +18,8 @@ export default function Data() {
       <Row>
         {AllDatasets.map((d) => {
           return (
-            <Col xs={12} md={4} key={d.objectKey} className='mx-auto mb-4'>
-              <DataCard
-                title={d.title}
-                objectKey={d.objectKey}
-                description={d.description}
-                imagingPlatform={d.imagingPlatform}
-                samples={d.samples}
-                thumbnail={d.thumbnail}
-              />
+            <Col xs={12} md={4} key={d.title} className='mx-auto mb-4'>
+              <DataCard dataset={d} />
             </Col>
           );
         })}

--- a/frontend/src/datasets/DataCard.tsx
+++ b/frontend/src/datasets/DataCard.tsx
@@ -41,8 +41,6 @@ export default function DataCard({ dataset }: DataCardProps) {
     }
   };
 
-  // const onVersionClick = (v: Dataset['versions'][0]) => {
-
   return (
     <Card>
       <Card.Img variant='top' src={thumbnail} />

--- a/frontend/src/datasets/DataCard.tsx
+++ b/frontend/src/datasets/DataCard.tsx
@@ -1,24 +1,31 @@
 import { useState } from 'react';
 import { Storage } from '@aws-amplify/storage';
-import Alert from 'react-bootstrap/Alert';
-import Button from 'react-bootstrap/Button';
-import Card from 'react-bootstrap/Card';
-import ListGroup from 'react-bootstrap/ListGroup';
-import ListGroupItem from 'react-bootstrap/ListGroupItem';
+import { Dataset } from './AllDatasets';
+import {
+  Alert,
+  Button,
+  Card,
+  ListGroup,
+  ListGroupItem,
+  Container,
+  Dropdown,
+  Row,
+} from 'react-bootstrap';
 
 const openInNewTab = (url: string) => {
   const newWindow = window.open(url, '_blank', 'noopener,noreferrer');
   if (newWindow) newWindow.opener = null;
 };
 
-export default function DataCard(props: any) {
+type DataCardProps = {
+  dataset: Dataset;
+};
+
+export default function DataCard({ dataset }: DataCardProps) {
   const [error, setError] = useState<string | null>(null);
-  const title = props.title || 'Data Title';
-  const description = props.description || 'Data description';
-  const samples = props.samples || 'Types of images';
-  const imagingPlatform = props.imagingPlatform || 'Imaging Platform';
-  const thumbnail = props.thumbnail || '';
-  const objectKey = props.objectKey || '';
+  const { title, samples, imagingPlatform, thumbnail, versions } = dataset;
+  const [version, setVersion] = useState(versions[0]);
+  const { version: versionNumber, description, objectKey } = version;
 
   const onClick = async () => {
     try {
@@ -33,6 +40,8 @@ export default function DataCard(props: any) {
       setError(JSON.stringify(err));
     }
   };
+
+  // const onVersionClick = (v: Dataset['versions'][0]) => {
 
   return (
     <Card>
@@ -56,9 +65,25 @@ export default function DataCard(props: any) {
             </Card.Text>
           </ListGroupItem>
         </ListGroup>
-        <Button variant='dark' onClick={onClick}>
-          Download
-        </Button>
+        <Container>
+          <Row className='justify-content-between'>
+            <Dropdown>
+              <Dropdown.Toggle variant='dark' id='dropdown-basic'>
+                Version: {versionNumber}
+              </Dropdown.Toggle>
+              <Dropdown.Menu>
+                {versions.map((v) => (
+                  <Dropdown.Item key={v.version} onClick={() => setVersion(v)}>
+                    {v.version}
+                  </Dropdown.Item>
+                ))}
+              </Dropdown.Menu>
+            </Dropdown>
+            <Button variant='dark' onClick={onClick}>
+              Download
+            </Button>
+          </Row>
+        </Container>
         {error !== null ? (
           <Alert variant='danger' dismissible onClose={() => setError(null)}>
             {error}


### PR DESCRIPTION
Coming up on a new release of TissueNet, this adds a version dropdown option. Each version parameterizes the version number, a description of the version, and the file to download. Here's what the updated UI looks like:

<img width="416" alt="Screen Shot 2022-04-22 at 1 45 42 PM" src="https://user-images.githubusercontent.com/40068392/164793743-bf78e05d-7dd7-4da6-ba1e-f1d3fec2e831.png">


I also added a missing .prettierrc.json to make the local prettier config match the pre-commit config.