### PR TITLE
Make most recent dataset version the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ DeepCell Datasets is a serverless applicatioin that allows authenticated users t
 This is aided by using `lerna` as well as the `serverless` framework.
 `lerna` enables us to easily control all of the services from the root directory, while `serverless` allows us to deploy and manage AWS infrastructure through `.yml` configuration files.
 
+Make sure serverless is installed by running `npm install -g serverless@2`.
+
 ### Deployment
 
 `lerna` is used to manage and deploy both the frontend and the application services with a simple `yarn` or `npm` command:

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 ## Getting Started
 
 DeepCell Datasets is a serverless applicatioin that allows authenticated users to access published datasets.
-This is aided by using `lectra` as well as the `serverless` framework.
+This is aided by using `lerna` as well as the `serverless` framework.
 `lerna` enables us to easily control all of the services from the root directory, while `serverless` allows us to deploy and manage AWS infrastructure through `.yml` configuration files.
 
 ### Deployment
 
-`lectra` is used to manage and deploy both the frontend and the application services with a simple `yarn` or `npm` command:
+`lerna` is used to manage and deploy both the frontend and the application services with a simple `yarn` or `npm` command:
 
 ```bash
 yarn deploy:dev

--- a/frontend/src/datasets/DataCard.tsx
+++ b/frontend/src/datasets/DataCard.tsx
@@ -24,7 +24,7 @@ type DataCardProps = {
 export default function DataCard({ dataset }: DataCardProps) {
   const [error, setError] = useState<string | null>(null);
   const { title, samples, imagingPlatform, thumbnail, versions } = dataset;
-  const [version, setVersion] = useState(versions[0]);
+  const [version, setVersion] = useState(versions[versions.length - 1]);
   const { version: versionNumber, description, objectKey } = version;
 
   const onClick = async () => {


### PR DESCRIPTION
A quick change to make the default dropdown option the last element of the version list, which assumes that the version list is in order of oldest to newest.

Also some small changes and additions to the readme about lerna and serverless.